### PR TITLE
Update to new BeatSaver API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-playlist-cli",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -38,9 +38,9 @@
       }
     },
     "@types/node": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.2.tgz",
-      "integrity": "sha512-vxyhOzFCm+jC/T5KugbVsYy1DbQM0h3NCFUrVbu0+pYa/nr+heeucpqxpa8j4pUmIGLPYzboY9zIdOF0niFAjQ==",
+      "version": "16.4.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
+      "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==",
       "dev": true
     },
     "@types/yargs": {
@@ -86,11 +86,12 @@
       }
     },
     "beatsaver-api": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/beatsaver-api/-/beatsaver-api-1.0.1.tgz",
-      "integrity": "sha512-lnvcKaN36pwkcnf4dZzJT/+EC4eVnScnk7nkwHUCG8VEvHGcxM+E987CDBXba7UhdGwy4ny5l6L/aU890QVnpg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/beatsaver-api/-/beatsaver-api-2.0.0.tgz",
+      "integrity": "sha512-UQV7Ff3jYzrbZHdFpIqMvvdqfHOBjEyi99LeQafXztxB48HClzf9cnQPaw85mw5rLM8lj41+3BcqBQWnMgAmGg==",
       "requires": {
         "axios": "^0.21.1",
+        "detect-node": "^2.1.0",
         "semver": "^7.3.5",
         "tslib": "^2.3.0"
       }
@@ -134,6 +135,11 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "diff": {
       "version": "4.0.2",
@@ -277,9 +283,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
-      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.0.tgz",
+      "integrity": "sha512-SQr7qqmQ2sNijjJGHL4u7t8vyDZdZ3Ahkmo4sc1w5xI9TBX0QDdG/g4SFnxtWOsGLjwHQue57eFALfwFCnixgg==",
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   "license": "ISC",
   "devDependencies": {
     "@types/colors": "^1.2.1",
-    "@types/node": "^16.4.2",
+    "@types/node": "^16.4.13",
     "@types/yargs": "^17.0.2",
     "ts-node": "^10.1.0",
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "beatsaver-api": "^1.0.1",
+    "beatsaver-api": "^2.0.0",
     "colors": "^1.4.0",
-    "yargs": "^17.0.1"
+    "yargs": "^17.1.0"
   }
 }

--- a/src/utils/getSong.ts
+++ b/src/utils/getSong.ts
@@ -1,17 +1,18 @@
+import BeatSaverAPI from 'beatsaver-api';
 import { SongProps } from '../types';
 import { plain, succ, err, k } from './log';
 
-export const getSong = async (api: any, key: string): Promise<SongProps> => {
+export const getSong = async (api: BeatSaverAPI, key: string): Promise<SongProps> => {
   try {
     plain(`Started adding ${k(key)}`);
 
-    const map = await api.getMapDetailsByKey(key);
+    const map = await api.getMapByID(key);
 
     const mapEntry: SongProps = {
-      songName: map?.name!,
-      hash: map?.hash!,
-      levelid: map?._id!,
-      levelAuthorName: map?.uploader?.username!,
+      songName: map.name,
+      hash: map.versions[0].hash,
+      levelid: map.id,
+      levelAuthorName: map.uploader.name,
     };
 
     succ(`Finished adding ${k(key)}`);


### PR DESCRIPTION
This pull request:
- Updates [@types/node](https://www.npmjs.com/package/@types/node) from version `16.4.2` to version `16.4.13`
- Updates [yargs](https://www.npmjs.com/package/yargs) from version `17.0.1` to version `17.1.0`
- Updates [beatsaver-api](https://www.npmjs.com/package/beatsaver-api) from version `1.0.1` to version `2.0.0`
- Changes the `getSong` method to implement the [`beatsaver-api`'s breaking changes on v2.0.0](https://github.com/rui2015/beatsaver-api/blob/master/BREAKING-CHANGES.md)